### PR TITLE
Fix doc

### DIFF
--- a/docs/source/training/llama_factory.rst
+++ b/docs/source/training/llama_factory.rst
@@ -118,8 +118,8 @@ your dataset as follows.
        "tags": {
          "role_tag": "from",
          "content_tag": "value",
-         "user_tag": "user",
-         "assistant_tag": "assistant"
+         "user_tag": "human",
+         "assistant_tag": "gpt"
        }
      }
 


### PR DESCRIPTION
LLama-factory的训练文档有处不一致，原始文档中，构建sharegpt格式数据时，文档给出的示例是：
`dataset.json`
```
[
  {
    "conversations": [
      {
        "from": "human",
        "value": "user instruction"
      },
      {
        "from": "gpt",
        "value": "model response"
      }
    ],
    "system": "system prompt (optional)",
    "tools": "tool description (optional)"
  }
]
```
`dataset_info.json`
```
"dataset_name": {
    "file_name": "dataset_name.json",
    "formatting": "sharegpt",
    "columns": {
      "messages": "conversations",
      "system": "system",
      "tools": "tools"
    },
    "tags": {
      "role_tag": "from",
      "content_tag": "value",
      "user_tag": "user",
      "assistant_tag": "assistant"
    }
  }
```
其中，`dataset_info.json`的user_tag和assistant_tag与`dataset.json`的tag不一致，会导致LLama-factory训练时报错`raise ValueError("Invalid role tag in {}.".format(messages))`

这个pr修改了相应的内容，使`dataset_info.json`和`dataset.json`中的tag一致