### PR TITLE
docs(deployment): Update YaRN configuration example in SGLang deploym…

### DIFF
--- a/docs/source/deployment/sglang.md
+++ b/docs/source/deployment/sglang.md
@@ -228,7 +228,7 @@ We have validated the performance of [YaRN](https://arxiv.org/abs/2309.00071), a
 
 SGLang supports YaRN, which can be configured as
 ```shell
-python -m sglang.launch_server --model-path Qwen/Qwen3-8B --json-model-override-args '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}}'
+python -m sglang.launch_server --model-path Qwen/Qwen3-8B --json-model-override-args '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}}' --context-length 131072
 ```
 
 :::{note}


### PR DESCRIPTION
…ent documentation

- Added the `--context-length 131072` parameter to the YaRN configuration example