### PR TITLE
docs: fix dead anchor in function-calling cross-reference

### DIFF
--- a/docs/source/inference/transformers.md
+++ b/docs/source/inference/transformers.md
@@ -130,7 +130,7 @@ def parse_thinking_content(messages):
 
 ## Parsing Tool Calls
 
-For tool calling with Transformers, please refer to [our guide on Function Calling](../framework/function_call.md#hugging-face-transformers).
+For tool calling with Transformers, please refer to [our guide on Function Calling](../framework/function_call.md).
 
 ## Serving Quantized models
 


### PR DESCRIPTION
In `docs/source/inference/transformers.md`, the "Parsing Tool Calls" section links to:

```
[our guide on Function Calling](../framework/function_call.md#hugging-face-transformers)
```

But `function_call.md` has no "Hugging Face Transformers" section — its headings are *Preface / What is function calling / Inference with Function Calling / The Example Case / Qwen-Agent / vLLM / Finally* (a grep for "hugging" returns 0). So the `#hugging-face-transformers` fragment matches no anchor, and the link lands on the top of the page instead of a relevant section.

This drops the dead fragment so the link points at the guide itself. Docs-only, one line.