### PR TITLE
Docs: document thinking_budget for DashScope thinking mode

### DIFF
--- a/docs/source/framework/qwen_agent.rst
+++ b/docs/source/framework/qwen_agent.rst
@@ -68,6 +68,7 @@ yourself.
    #         # 'generate_cfg': {
    #         #     # When using the Dash Scope API, pass the parameter of whether to enable thinking mode in this way
    #         #     'enable_thinking': False,
+   #         #     'thinking_budget': 12000,  # required when enable_thinking=True; must be a positive integer <= model max thinking length
    #         # },
    # }
    # llm_cfg = {
@@ -79,7 +80,8 @@ yourself.
    #     # 'generate_cfg': {
    #     #     # When using Dash Scope OAI API, pass the parameter of whether to enable thinking mode in this way
    #     #     'extra_body': {
-   #     #         'enable_thinking': False
+   #     #         'enable_thinking': False,
+   #     #         'thinking_budget': 12000,  # required when enable_thinking=True
    #     #     },
    #     # },
    # }


### PR DESCRIPTION
Addresses #941.

Adds `thinking_budget` to the DashScope and DashScope OpenAI-compatible examples in the Qwen-Agent doc page:

- DashScope API: `'thinking_budget': 12000`
- DashScope OAI API: `'extra_body': {'thinking_budget': 12000}`

It must be a positive integer not exceeding the model's max thinking length. Without it, enabling thinking mode on DashScope returns:

```
<400> InternalError.Algo.InvalidParameter: The thinking_budget parameter must be a positive integer and not greater than 0
```